### PR TITLE
Ensure standard VBA type casing

### DIFF
--- a/Slicer & Pivot v3.bas
+++ b/Slicer & Pivot v3.bas
@@ -52,7 +52,7 @@ Sub CreatePivotTablesAndSlicers()
         Set pRange = wsData.Range(wsData.Cells(1, colIndex), wsData.Cells(lastRow, colIndex))
 
         ' Create a Pivot Table
-        Set pt = wsPivot.pivotTables.Add(PivotCache:=pc, TableDestination:=wsPivot.Cells(pivotRow, 1))
+        Set pt = wsPivot.PivotTables.Add(PivotCache:=pc, TableDestination:=wsPivot.Cells(pivotRow, 1))
 
         ' Set Pivot Table fields
         With pt


### PR DESCRIPTION
## Summary
- unify `PivotTables` casing when creating pivot tables

## Testing
- `grep -ni 'pivottable' -n *.bas`

------
https://chatgpt.com/codex/tasks/task_e_6863b61fae4c832fabf8323c523d1e67